### PR TITLE
Remove python 3.3 and 3.4 from allowed_failures

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,9 +8,6 @@ python:
 
 matrix:
   fast_finish: true
-  allow_failures:
-    - python: "3.3"
-    - python: "3.4"
 
 # command to install dependencies
 install:


### PR DESCRIPTION
Now that the Python 3 tests are passing, we shouldn't allow those to fail any longer.
