### PR TITLE
Recognize long integers as integers. Fixes #6.

### DIFF
--- a/ntlm3/U32.py
+++ b/ntlm3/U32.py
@@ -28,7 +28,7 @@ class U32:
     v = 0
 
     def __init__(self, value=0):
-        if type(value) != int:
+        if not isinstance(value, (int, long)):
             value = six.byte2int(value)
 
         self.v = C + norm(abs(int(value)))

--- a/ntlm3/U32.py
+++ b/ntlm3/U32.py
@@ -28,7 +28,7 @@ class U32:
     v = 0
 
     def __init__(self, value=0):
-        if not isinstance(value, (int, long)):
+        if not isinstance(value, six.integer_types):
             value = six.byte2int(value)
 
         self.v = C + norm(abs(int(value)))


### PR DESCRIPTION
I can reproduce the issue, and it seems like the values from des_data.py are coming in as longs, and being misidentified as not integer-like. This change seems to fix the problem, and I can import ntlm3 and connect to a local NTLM server via requests_ntlm after this fix.