### PR TITLE
Fix issue 15: Incorrect module name used when referring to URLError in HTTPNtlmAuthHandler line 126

### DIFF
--- a/ntlm3/HTTPNtlmAuthHandler.py
+++ b/ntlm3/HTTPNtlmAuthHandler.py
@@ -123,7 +123,7 @@ class AbstractNtlmAuthHandler:
                 infourl.msg = response.reason
                 return infourl
             except socket.error as err:
-                raise urllib.URLError(err)
+                raise urllib.error.URLError(err)
         else:
             return None
 


### PR DESCRIPTION
Fix issue 15: Incorrect module name used when referring to URLError in HTTPNtlmAuthHandler line 126
