### PR TITLE
add support for SMTP server authentication using NTLM

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,3 +34,8 @@ API
 ----------
 
 TODO
+
+
+Examples
+--------
+In the examples folder, there are 2 examples, one for accessing a URL behind NTLM authentication, and one for sending an email through a SMTP server using NTLM authentication. Each file's usage is documented at the top of the file

--- a/examples/smtp.py
+++ b/examples/smtp.py
@@ -1,0 +1,58 @@
+#! /usr/bin/env python
+
+"""
+A simple script to demonstrate how this package works with an SMTP server.
+
+Run with:
+
+    python simple.py --username "DOMAIN\\username" --host "some.smtp.server" --port 25 --fromE "my@email.com" --subject "some subject" --body "some body"
+
+The script will prompt you for a password, or you can specify one with --password <password> if you prefer.
+
+Inspired from
+https://docs.python.org/2/library/smtplib.html#smtp-example
+and
+https://docs.python.org/2/library/email-examples.html#email-examples
+
+"""
+import getpass
+
+try:
+    import argparse
+except ImportError:
+    raise SystemExit("Hi, I see you're on Python 2.6. Please run 'pip install argparse' and try again.")
+
+import ntlm3 as ntlm
+import smtplib
+from email.mime.text import MIMEText
+
+def process(user, password, host, port, fromE, to, subject, body):
+    smtp = smtplib.SMTP(host, port)
+    smtp.set_debuglevel(True)
+    smtp.ehlo()
+    ntlm.smtp.ntlm_authenticate(smtp, user, password)
+    msg = MIMEText(body)
+    msg['Subject']=subject
+    msg['From']=fromE
+    msg['To']=to
+    smtp.sendmail(fromE, [to], msg.as_string())
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    parser.add_argument('--host', help='A SMTP server with NTLM auth', required=True)
+    parser.add_argument('-u', '--username', help='Your username, in the form "DOMAIN\\username"', required=True)
+    parser.add_argument('-p', '--password', help='Your password. Optional, the script will prompt for it.')
+    parser.add_argument('-l', '--port', help='server port number')
+    parser.add_argument('-f', '--fromE', help='from email to use')
+    parser.add_argument('-t', '--to', help='to email')
+    parser.add_argument('-s', '--subject', help='email subject')
+    parser.add_argument('-b', '--body', help='email body')
+
+    args = parser.parse_args()
+
+    if args.password:
+        password = args.password
+    else:
+        password = getpass.getpass()
+
+    process(user=args.username, password=password, host=args.host, port=args.port, to=args.to, fromE=args.fromE, subject=args.subject, body=args.body)

--- a/ntlm3/__init__.py
+++ b/ntlm3/__init__.py
@@ -1,5 +1,5 @@
 
-from . import HTTPNtlmAuthHandler  # noqa
+from . import HTTPNtlmAuthHandler, smtp  # noqa
 
 
-__all__ = ('HTTPNtlmAuthHandler')
+__all__ = ('HTTPNtlmAuthHandler', 'smtp')

--- a/ntlm3/smtp.py
+++ b/ntlm3/smtp.py
@@ -1,0 +1,42 @@
+# Referenced from
+# https://www.pythondiary.com/tutorials/django-ntlm-smtp-auth.html
+# Downloaded from
+# https://code.google.com/archive/p/python-ntlm/issues/14
+
+# This library is free software: you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public
+# License as published by the Free Software Foundation, either
+# version 3 of the License, or (at your option) any later version.
+
+# This library is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# Lesser General Public License for more details.
+# 
+# You should have received a copy of the GNU Lesser General Public
+# License along with this library.  If not, see <http://www.gnu.org/licenses/> or <http://www.gnu.org/licenses/lgpl.txt>.
+
+#from HTTPNtlmAuthHandler import asbase64
+from .ntlm import create_NTLM_NEGOTIATE_MESSAGE, parse_NTLM_CHALLENGE_MESSAGE, create_NTLM_AUTHENTICATE_MESSAGE
+from smtplib import SMTPException, SMTPAuthenticationError
+
+
+def ntlm_authenticate(smtp, username, password):
+#    """Example:
+#    >>> import smtplib
+#    >>> smtp = smtplib.SMTP("my.smtp.server")
+#    >>> smtp.ehlo()
+#    >>> ntlm_authenticate(smtp, r"DOMAIN\username", "password")
+#    """
+    args = "NTLM " + create_NTLM_NEGOTIATE_MESSAGE(username).decode("utf-8")
+
+    code, response = smtp.docmd("AUTH", args)
+    if code != 334:
+        raise SMTPException("Server did not respond as expected to NTLM negotiate message")
+    challenge, flags = parse_NTLM_CHALLENGE_MESSAGE(response)
+    user_parts = username.split("\\", 1)
+    args = create_NTLM_AUTHENTICATE_MESSAGE(challenge, user_parts[1], user_parts[0], password, flags)
+    args = args.decode("utf-8")
+    code, response = smtp.docmd("", args)
+    if code != 235:
+        raise SMTPAuthenticationError(code, response)


### PR DESCRIPTION
- Largely copied from https://www.pythondiary.com/tutorials/django-ntlm-smtp-auth.html
- includes the case of `decode('utf-8')` as documented in #23 and solved by https://github.com/arijeetmkh/python-ntlm3/commit/5f75780869cc8b4892b23661b9b753e90dae392a
- also included an example script to demonstrate sending emails through such server