### PR TITLE
fix ill formatted http Authorization string

### DIFF
--- a/ntlm3/HTTPNtlmAuthHandler.py
+++ b/ntlm3/HTTPNtlmAuthHandler.py
@@ -54,7 +54,7 @@ class AbstractNtlmAuthHandler:
                 # ntlm secures a socket, so we must use the same socket for the complete handshake
             headers = dict(req.headers)
             headers.update(req.unredirected_hdrs)
-            auth = 'NTLM %s' % ntlm.create_NTLM_NEGOTIATE_MESSAGE(user, type1_flags)
+            auth = 'NTLM %s' % ntlm.create_NTLM_NEGOTIATE_MESSAGE(user, type1_flags).decode('ascii')
             if req.headers.get(self.auth_header, None) == auth:
                 return None
             headers[self.auth_header] = auth
@@ -105,7 +105,7 @@ class AbstractNtlmAuthHandler:
 
             (ServerChallenge, NegotiateFlags) = ntlm.parse_NTLM_CHALLENGE_MESSAGE(auth_header_value[5:])
             auth = 'NTLM %s' % ntlm.create_NTLM_AUTHENTICATE_MESSAGE(ServerChallenge, UserName, DomainName, pw,
-                                                                     NegotiateFlags)
+                                                                     NegotiateFlags).decode('ascii')
             headers[self.auth_header] = auth
             headers["Connection"] = "Close"
             headers = dict((name.title(), val) for name, val in headers.items())


### PR DESCRIPTION
with python3, the NTLM Authorization string is of byte type.

when concatenating it with the prefix, python adds b'' around the authorization string.

for example, instead of generating:

Authorization: NTLM TlRMTVNTUAABAAAAB7IIogoACgAyBBBBCgAKACgBBBBFASgKAAAAD1NISVktUDlYNzlOVklESUEuQ09N

as would by python-ntlm,

python-ntlm3 generated:

Authorization: NTLM b'TlRMTVNTUAABAAAAB7IIogoACgAyBBBBCgAKACgBBBBFASgKAAAAD1NISVktUDlYNzlOVklESUEuQ09N'

this resulted in server rejection (http 400 bad request)